### PR TITLE
Fix small typos and enhance data collator test

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -273,7 +273,7 @@ class DataCollatorCTCWithPadding:
     pad_to_multiple_of_labels: Optional[int] = None
 
     def __call__(self, features: List[Dict[str, Union[List[int], torch.Tensor]]]) -> Dict[str, torch.Tensor]:
-        # split inputs and labels since they have to be of different lenghts and need
+        # split inputs and labels since they have to be of different lengths and need
         # different padding methods
         input_features = [{"input_values": feature["input_values"]} for feature in features]
         label_features = [{"input_ids": feature["labels"]} for feature in features]

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -118,7 +118,7 @@ def torch_default_data_collator(features: List[InputDataClass]) -> Dict[str, Any
         if isinstance(first["label_ids"], torch.Tensor):
             batch["labels"] = torch.stack([f["label_ids"] for f in features])
         else:
-            dtype = torch.long if type(first["label_ids"][0]) is int else torch.float
+            dtype = torch.long if isinstance(first["label_ids"][0], int) else torch.float
             batch["labels"] = torch.tensor([f["label_ids"] for f in features], dtype=dtype)
 
     # Handling of all other possible keys.
@@ -194,7 +194,7 @@ def numpy_default_data_collator(features: List[InputDataClass]) -> Dict[str, Any
         if isinstance(first["label_ids"], np.ndarray):
             batch["labels"] = np.stack([f["label_ids"] for f in features])
         else:
-            dtype = np.int64 if type(first["label_ids"][0]) is int else np.float32
+            dtype = np.int64 if isinstance(first["label_ids"][0], int) else np.float32
             batch["labels"] = np.array([f["label_ids"] for f in features], dtype=dtype)
 
     # Handling of all other possible keys.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -395,7 +395,7 @@ class TrainingArguments:
             down the training and evaluation speed.
         push_to_hub (`bool`, *optional*, defaults to `False`):
             Whether or not to push the model to the Hub every time the model is saved. If this is activated,
-            `output_dir` will begin a git directory synced with the the repo (determined by `hub_model_id`) and the
+            `output_dir` will begin a git directory synced with the repo (determined by `hub_model_id`) and the
             content will be pushed each time a save is triggered (depending on your `save_strategy`). Calling
             [`~Trainer.save_model`] will also trigger a push.
 

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -68,6 +68,15 @@ class DataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"].dtype, torch.long)
         self.assertEqual(batch["inputs"].shape, torch.Size([8, 6]))
 
+        # With label_ids as numpy integers
+        features = [
+            {"label_ids": np.array([0, 1, 2], dtype=np.int64), "inputs": [0, 1, 2, 3, 4, 5]}
+            for i in range(8)
+        ]
+        batch = default_data_collator(features)
+        self.assertTrue(batch["labels"].equal(torch.tensor([[0, 1, 2]] * 8)))
+        self.assertEqual(batch["labels"].dtype, torch.long)
+
         # Features can already be tensors
         features = [{"label": i, "inputs": np.random.randint(0, 10, [10])} for i in range(8)]
         batch = default_data_collator(features)


### PR DESCRIPTION
## Summary
- correct 'lenghts' typo in speech recognition example
- use `isinstance` to pick dtype in data collators
- fix duplicated word in TrainingArguments documentation
- test torch default data collator with numpy integer label IDs

## Testing
- `pytest tests/trainer/test_data_collator.py::DataCollatorIntegrationTest::test_default_with_dict -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a6817304bc833196329de64ce7c167